### PR TITLE
Multiple Orbits per page

### DIFF
--- a/jquery.orbit.js
+++ b/jquery.orbit.js
@@ -134,7 +134,7 @@
             if(options.timer) {         	
                 var timerHTML = '<div class="timer"><span class="mask"><span class="rotator"></span></span><span class="pause"></span></div>'
                 orbitWrapper.append(timerHTML);
-                var timer = $('div.timer'),
+                var timer = orbitWrapper.children('div.timer'),
                 	timerRunning;
                 if(timer.length != 0) {
                     var rotator = $('div.timer span.rotator'),
@@ -250,7 +250,7 @@
             if(options.bullets) { 
             	var bulletHTML = '<ul class="orbit-bullets"></ul>';            	
             	orbitWrapper.append(bulletHTML);
-            	var bullets = $('ul.orbit-bullets');
+            	var bullets = orbitWrapper.children('ul.orbit-bullets');
             	for(i=0; i<numberSlides; i++) {
             		var liMarkup = $('<li>'+(i+1)+'</li>');
             		if(options.bulletThumbs) {
@@ -260,7 +260,7 @@
             				liMarkup.css({"background" : "url("+options.bulletThumbLocation+thumbName+") no-repeat"});
             			}
             		} 
-            		$('ul.orbit-bullets').append(liMarkup);
+            		orbitWrapper.children('ul.orbit-bullets').append(liMarkup);
             		liMarkup.data('index',i);
             		liMarkup.click(function() {
             			stopClock();


### PR DESCRIPTION
Hello,

I love the simplicity of the Orbit plugin but encountered some limitation for putting more than one Orbit on a page. Fortunately the fix is very easy and consists of three simple changes to the code. Basically, we need to make sure to only search for and append to the HTML elements in the current Orbit.

Hope this makes sense and that you could include the fix in a next version.

–Benjamin
