### PR TITLE
Fixed bug in caption handling + added a way to have slides w/ caption inside a link

### DIFF
--- a/jquery.orbit-1.2.3.js
+++ b/jquery.orbit-1.2.3.js
@@ -197,7 +197,13 @@
             	if(!options.captions || options.captions =="false") {
             		return false; 
             	} else {
-	            	var _captionLocation = slides.eq(activeSlide).data('caption'); //get ID from rel tag on image
+	            	if($(slides.eq(activeSlide).html()).attr('data-caption') !== undefined) {
+						var _captionLocation = $(slides.eq(activeSlide).html()).attr('data-caption'); //get ID from data-caption tag inside a <a>
+					} else {
+						var _captionLocation = slides.eq(activeSlide).attr('data-caption'); //get ID from data-caption tag on image
+
+					}
+	            	console.log('caption location : '+_captionLocation);
 	            		_captionHTML = $(_captionLocation).html(); //get HTML from the matching HTML entity            		
 	            	//Set HTML for the caption if it exists
 	            	if(_captionHTML) {

--- a/jquery.orbit-1.2.3.js
+++ b/jquery.orbit-1.2.3.js
@@ -203,8 +203,7 @@
 						var _captionLocation = slides.eq(activeSlide).attr('data-caption'); //get ID from data-caption tag on image
 
 					}
-	            	console.log('caption location : '+_captionLocation);
-	            		_captionHTML = $(_captionLocation).html(); //get HTML from the matching HTML entity            		
+					_captionHTML = $(_captionLocation).html(); //get HTML from the matching HTML entity            		
 	            	//Set HTML for the caption if it exists
 	            	if(_captionHTML) {
 	            		caption
@@ -404,4 +403,3 @@
         });//each call
     }//orbit plugin call
 })(jQuery);
-        


### PR DESCRIPTION
Hey guys,

There was a little nasty bug : you looked for slides.eq(activeSlide).data("caption") wheras your doc is telling us that a tag data-caption was where you stored the ID of the caption.
So you surely meant something like slides.eq(activeSlide).attr("data-caption"), no ?
In the meantime, I didn't dug that deep, and your examples do work, so maybe the real problem is little more complicated than that.
Anyway, I fixed my invisibles captions with that workaround, so here it is.

And, bonus : I added a way to have slides(+caption) inside a link.
I would have liked to have my slides inside a <a>, like this <a href="..."><img src="..." data-caption="caption"></a> ; wasn't possible until there.
So there it is :)
