### PR TITLE
Allow easy access to the previos and active slide in the afterSlideChange

### DIFF
--- a/jquery.orbit-1.2.3.js
+++ b/jquery.orbit-1.2.3.js
@@ -305,7 +305,7 @@
                     	.eq(prevActiveSlide)
                     	.css({"z-index" : 1});
                     unlock();
-                    options.afterSlideChange.call(this);
+                    options.afterSlideChange.call(this, slides.eq(prevActiveSlide), slides.eq(activeSlide));
                 }
                 if(slides.length == "1") { return false; }
                 if(!locked) {


### PR DESCRIPTION
Allow easy access to the previos and active slide in the afterSlideChange callback.
