### PR TITLE
orbitWidth not getting set on initialization

### DIFF
--- a/jquery.orbit-1.2.3.js
+++ b/jquery.orbit-1.2.3.js
@@ -59,12 +59,16 @@
                 	_slideHeight = _slide.height();
                 if(_slideWidth > orbit.width()) {
 	                orbit.add(orbitWrapper).width(_slideWidth);
-	                orbitWidth = orbit.width();	       			
-	            }
-	            if(_slideHeight > orbit.height()) {
+	              } 
+	              // setting this because orbit width is not always less than slidewidth
+	              // and orbitHeight and width aren't initialized
+	              orbitWidth = orbit.width();	       			
+	              if(_slideHeight > orbit.height()) {
 	                orbit.add(orbitWrapper).height(_slideHeight);
-	                orbitHeight = orbit.height();
-				}
+				        }
+				        // setting this because orbit height is not always less than slideheight
+				        // and orbitHeight and width aren't initialized
+				        orbitHeight = orbit.height();
                 numberSlides++;
             });
             


### PR DESCRIPTION
In my case the orbit.width() was being set to a value greater than the slide width.  orbitWidth never gets set with this case causing the animations to fail.  I added a way to set orbitWidth no matter if the slide width is greater or not.  After writing this it might just be better to set a default in the initialization but you can do that.
