### PR TITLE
Option: advance to next slide on click

### DIFF
--- a/jquery.orbit-1.3.0.js
+++ b/jquery.orbit-1.3.0.js
@@ -27,7 +27,8 @@
       bulletThumbs: false,				// thumbnails for the bullets
       bulletThumbLocation: '',			// location from this file where thumbs will be
       afterSlideChange: $.noop,		// empty function 
-      centerBullets: true    // center bullet nav with js, turn this off if you want to position the bullet nav manually
+      centerBullets: true,    // center bullet nav with js, turn this off if you want to position the bullet nav manually
+      advanceOnClick: false    // if you want the slide to advance if user clicks on it
  	  },
  	  
  	  activeSlide: 0,
@@ -126,6 +127,10 @@
       if (this.options.bullets) {
         this.setupBulletNav();
         this.setActiveBullet();
+      }
+      
+      if (this.options.advanceOnClick) {
+          this.setupAdvanceOnClick();
       }
     },
     
@@ -333,6 +338,14 @@
         self.stopClock();
         self.$element.trigger('orbit.next');
       });
+    },
+    
+    setupAdvanceOnClick: function() {
+        var self = this;
+        $(this.$slides).click(function(evt) {
+            self.stopClock();
+            self.$element.trigger('orbit.next');
+        });
     },
     
     setupBulletNav: function () {


### PR DESCRIPTION
Added an option advanceOnClick which, when set to true, will advance to the next slide if the user clicks anywhere on the image. This behavior is useful if you're using Orbit for a linear progression of images like a feature tour.

Clicking on the caption won't advance the slide and if the image itself is wrapped in an <a> tag (as in the demo.html) it should still behave as a normal link.
