### PR TITLE
Let user choose if clock should stop on clicking 'previous' or 'next'

### DIFF
--- a/jquery.orbit-1.3.0.js
+++ b/jquery.orbit-1.3.0.js
@@ -12,26 +12,26 @@
   var ORBIT = {
     
     defaults: {  
-      animation: 'horizontal-push', 		// fade, horizontal-slide, vertical-slide, horizontal-push, vertical-push
-      animationSpeed: 600, 				// how fast animtions are
-      timer: true, 						// true or false to have the timer
-      advanceSpeed: 4000, 				// if timer is enabled, time between transitions 
-      pauseOnHover: false, 				// if you hover pauses the slider
-      startClockOnMouseOut: false, 		// if clock should start on MouseOut
-      startClockOnMouseOutAfter: 1000, 	// how long after MouseOut should the timer start again
-      directionalNav: true, 				// manual advancing directional navs
-      captions: true, 					// do you want captions?
-      captionAnimation: 'fade', 			// fade, slideOpen, none
-      captionAnimationSpeed: 600, 		// if so how quickly should they animate in
-      bullets: false,						// true or false to activate the bullet navigation
-      bulletThumbs: false,				// thumbnails for the bullets
-      bulletThumbLocation: '',			// location from this file where thumbs will be
-      afterSlideChange: $.noop,		// empty function 
-      fluid: false,             // true or ratio (ex: 4x3) to force an aspect ratio for content slides, only works from within a fluid layout
-      centerBullets: true    // center bullet nav with js, turn this off if you want to position the bullet nav manually
- 	  },
- 	  
- 	  activeSlide: 0,
+      animation: 'horizontal-push',          // fade, horizontal-slide, vertical-slide, horizontal-push, vertical-push
+      animationSpeed: 600,                   // how fast animtions are
+      timer: true,                           // true or false to have the timer
+      advanceSpeed: 4000,                    // if timer is enabled, time between transitions
+      pauseOnHover: false,                   // if you hover pauses the slider
+      startClockOnMouseOut: false,           // if clock should start on MouseOut
+      startClockOnMouseOutAfter: 1000,       // how long after MouseOut should the timer start again
+      stopClockOnDirectionalNavClick: false, // if clock should stop on clicking previous or next
+      directionalNav: true,                  // manual advancing directional navs
+      captions: true,                        // do you want captions?
+      captionAnimation: 'fade',              // fade, slideOpen, none
+      captionAnimationSpeed: 600,            // if so how quickly should they animate in
+      bullets: false,                        // true or false to activate the bullet navigation
+      bulletThumbs: false,                   // thumbnails for the bullets
+      bulletThumbLocation: '',               // location from this file where thumbs will be
+      afterSlideChange: $.noop,              // empty function
+      fluid: false,                          // true or ratio (ex: 4x3) to force an aspect ratio for content slides, only works from within a fluid layout
+      centerBullets: true                    // center bullet nav with js, turn this off if you want to position the bullet nav manually
+    },
+    activeSlide: 0,
     numberSlides: 0,
     orbitWidth: null,
     orbitHeight: null,
@@ -353,14 +353,18 @@
       var self = this;
 
       this.$wrapper.append(this.directionalNavHTML);
-      
+
       this.$wrapper.find('.left').click(function () { 
-        self.stopClock();
+        if (self.options.stopClockOnDirectionalNavClick) {
+          self.stopClock();
+        }
         self.$element.trigger('orbit.prev');
       });
       
       this.$wrapper.find('.right').click(function () {
-        self.stopClock();
+        if (self.options.stopClockOnDirectionalNavClick) {
+          self.stopClock();
+        }
         self.$element.trigger('orbit.next');
       });
     },


### PR DESCRIPTION
I added the 'stopClockOnDirectionalNavClick' option to let the user choose if clock should stop on clicking previous or next. It defaults to false since I found people think the widget is broken when it stops on clicking 'previous' or 'next'.
